### PR TITLE
Fix occationally lost samples after startup

### DIFF
--- a/plugin/energymanagerimpl.h
+++ b/plugin/energymanagerimpl.h
@@ -36,6 +36,7 @@ private:
     void unwatchThing(const ThingId &thingId);
 
     void updatePowerBalance();
+    void updateThingPower(Thing *thing);
 
 private slots:
     void logDumpConsumers();


### PR DESCRIPTION
If a device doesn't produce any currentPower value change after startup until the first regular sample is created, we may miss the very first values.